### PR TITLE
Fix NoMethodError when no rows in result

### DIFF
--- a/lib/bigquery-client/jobs.rb
+++ b/lib/bigquery-client/jobs.rb
@@ -6,7 +6,7 @@ module BigQuery
       result = jobs_query(query, options)
       names = result['schema']['fields'].map {|field| field['name'] }
       types = result['schema']['fields'].map {|field| field['type'] }
-      records = if result['rows'] then result['rows'].map {|row| row['f'].map {|record| record['v'] } } else [] end
+      records = (result['rows'] || []).map {|row| row['f'].map {|record| record['v'] } }
       convert(records, types).map { |values| [names, values].transpose.to_h }
     end
 

--- a/lib/bigquery-client/jobs.rb
+++ b/lib/bigquery-client/jobs.rb
@@ -6,7 +6,7 @@ module BigQuery
       result = jobs_query(query, options)
       names = result['schema']['fields'].map {|field| field['name'] }
       types = result['schema']['fields'].map {|field| field['type'] }
-      records = result['rows'].map {|row| row['f'].map {|record| record['v'] } }
+      records = if result['rows'] then result['rows'].map {|row| row['f'].map {|record| record['v'] } } else [] end
       convert(records, types).map { |values| [names, values].transpose.to_h }
     end
 

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -12,11 +12,27 @@ class JobsTest < Test::Unit::TestCase
       100
   EOS
 
+  @@no_rows_query = <<-"EOS"
+    SELECT
+      born_alive_alive, mother_residence_state, is_male
+    FROM
+      publicdata:samples.natality
+    ORDER BY
+      day
+    LIMIT
+      0
+  EOS
+
   def test_sql
     result = $client.sql(@@query)
     assert { result.size == 100 }
     assert { result.sample["born_alive_alive"].is_a? Fixnum }
     assert { result.sample["mother_residence_state"].is_a? String }
     assert { result.sample["is_male"] == true || result.first["is_male"] == false }
+  end
+
+  def test_sql_when_no_rows
+    result = $client.sql(@@no_rows_query)
+    assert { result == [] }
   end
 end


### PR DESCRIPTION
When query matched no rows, `result['rows']` is nil. It cause "NoMethodError: undefined method `map' for nil:NilClass".
