### PR TITLE
Support tables result traverse pages

### DIFF
--- a/lib/bigquery-client/tables.rb
+++ b/lib/bigquery-client/tables.rb
@@ -3,7 +3,16 @@
 module BigQuery
   module Tables
     def tables(options = {})
-      (list_tables(options)['tables'] || []).map {|t| t['tableReference']['tableId'] }
+      table_list = []
+      token = nil
+      options[:maxResults] ||= 1000
+      begin
+        response = list_tables(options.merge(pageToken: token))
+        (response['tables'] || []).each do |t|
+          table_list << t['tableReference']['tableId']
+        end
+      end while token = response['nextPageToken']
+      table_list
     end
 
     def list_tables(options = {})

--- a/test/test_tables.rb
+++ b/test/test_tables.rb
@@ -8,6 +8,15 @@ class TablesTest < Test::Unit::TestCase
     assert { $client.tables.include?(table_name) }
   end
 
+  def test_table_pagination
+    5.times do |i|
+      table_name = __method__.to_s + "_#{i.to_s}"
+      schema = [{ name: 'bar', type: 'string' }]
+      $client.create_table(table_name, schema)
+    end
+    assert { $client.tables(maxResults: 1).count == 5 }
+  end
+
   def test_fetch_schema
     table_name = __method__.to_s
     schema = [{ name: 'bar', type: 'string' }]


### PR DESCRIPTION
tables returns only 1,000 tables
http://stackoverflow.com/questions/23574196/bigquery-tables-list-returns-only-1000-tables#
## TODO
- [ ] [problem] can not be fail test
